### PR TITLE
Add --organize-by-date flag and export metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ ss2db --report-id REPORT_ID --dry-run --verbose
 | `--skip-sql` | Skip SQL generation phase | `--skip-sql` |
 | `--input-data` | Use existing data file | `--input-data data.json` |
 | `--input-schema` | Use existing schema file | `--input-schema schema.json` |
+| `--organize-by-date` | Use YYYY-MM-DD as top-level output dir | `--organize-by-date` |
 | `--dry-run` | Show what would be done | `--dry-run` |
 | `--verbose` | Enable verbose logging | `--verbose` |
 | `--quiet` | Suppress non-error output | `--quiet` |
@@ -383,6 +384,20 @@ exports/
 │       └── ...
 ```
 
+**With `--organize-by-date`:**
+```
+exports/
+├── 2026-04-06/
+│   ├── {resource_id}/              # single sheet/report
+│   │   ├── {timestamp}_data.json
+│   │   └── ...
+│   └── {workspace_id}/            # workspace mode
+│       ├── {sheet_id_1}/
+│       │   └── ...
+│       └── {sheet_id_N}/
+│           └── ...
+```
+
 ### Data File Format
 
 ```json
@@ -392,6 +407,8 @@ exports/
     "name": "Project Data",
     "source_type": "report",
     "total_row_count": 1000,
+    "workspace_id": "1133727850647428",
+    "workspace_name": "My Workspace",
     "columns": [...]
   },
   "rows": [
@@ -406,6 +423,8 @@ exports/
   ]
 }
 ```
+
+**Note**: The `workspace_id` and `workspace_name` fields are included in the metadata only when processing sheets within a workspace (`--workspace-id`).
 
 ### Schema File Format
 

--- a/ss2db/main.py
+++ b/ss2db/main.py
@@ -2,6 +2,7 @@
 
 import sys
 import time
+from datetime import date, datetime
 from pathlib import Path
 from typing import Optional
 
@@ -34,6 +35,7 @@ from ss2db.database.mysql import generate_mysql_script
 @click.option("--skip-sql", is_flag=True, help="Skip SQL generation phase")
 @click.option("--input-data", type=click.Path(exists=True), help="Use existing data file")
 @click.option("--input-schema", type=click.Path(exists=True), help="Use existing schema file")
+@click.option("--organize-by-date", is_flag=True, help="Use current date (YYYY-MM-DD) as top-level output directory")
 @click.option("--dry-run", is_flag=True, help="Show what would be done without executing")
 @click.option("--verbose", "-v", is_flag=True, help="Enable verbose logging")
 @click.option("--quiet", "-q", is_flag=True, help="Suppress non-error output")
@@ -54,6 +56,7 @@ def main(
     skip_sql: bool,
     input_data: Optional[str],
     input_schema: Optional[str],
+    organize_by_date: bool,
     dry_run: bool,
     verbose: bool,
     quiet: bool,
@@ -117,8 +120,14 @@ def main(
             click.echo("Error: --max-workers can only be used with --workspace-id", err=True)
             sys.exit(1)
 
+        # Compute date prefix for --organize-by-date
+        date_prefix = date.today().isoformat() if organize_by_date else None
+
         if dry_run:
             logger.info("DRY RUN MODE - No files will be created or modified")
+
+        if date_prefix:
+            logger.info(f"Organizing output by date: {date_prefix}")
 
         logger.info(f"Database type: {app_config.database.type}")
 
@@ -159,6 +168,7 @@ def main(
                 app_config=app_config,
                 max_workers=effective_max_workers,
                 logger=logger,
+                date_prefix=date_prefix,
             )
 
             results = processor.process_workspace(
@@ -211,7 +221,8 @@ def main(
             input_data=input_data,
             input_schema=input_schema,
             dry_run=dry_run,
-            logger=logger
+            logger=logger,
+            date_prefix=date_prefix,
         )
 
         # Log completion
@@ -247,6 +258,9 @@ def execute_phases(
     logger,
     smartsheet_client: Optional[SmartsheetClient] = None,
     output_dir_override: Optional[Path] = None,
+    date_prefix: Optional[str] = None,
+    workspace_id: Optional[str] = None,
+    workspace_name: Optional[str] = None,
 ) -> bool:
     """Execute the processing phases.
 
@@ -255,6 +269,10 @@ def execute_phases(
             When provided, skips client creation and connection testing.
         output_dir_override: Optional path to override the default output directory.
             Used by workspace mode to nest output under workspace_id/sheet_id/.
+        date_prefix: Optional date string (YYYY-MM-DD) to use as top-level output directory.
+            Used by --organize-by-date flag.
+        workspace_id: Optional workspace ID to include in JSON data file metadata.
+        workspace_name: Optional workspace name to include in JSON data file metadata.
     """
 
     resource_id = sheet_id or report_id
@@ -262,7 +280,13 @@ def execute_phases(
 
     # Create output filenames
     timestamp = time.strftime(app_config.output.timestamp_format)
-    output_dir = output_dir_override or (Path(app_config.output.directory) / resource_id)
+    if output_dir_override:
+        output_dir = output_dir_override
+    else:
+        base = Path(app_config.output.directory)
+        if date_prefix:
+            base = base / date_prefix
+        output_dir = base / resource_id
 
     data_file = output_dir / f"{timestamp}_data.json"
     schema_file = output_dir / f"{timestamp}_schema.json"
@@ -317,6 +341,12 @@ def execute_phases(
                 logger.info("Getting schema information...")
                 schema = extractor.extract_schema(resource_id)
 
+                # Attach workspace metadata if processing within a workspace
+                if workspace_id:
+                    schema.workspace_id = workspace_id
+                if workspace_name:
+                    schema.workspace_name = workspace_name
+
                 # Extract data with progress tracking
                 logger.info(f"Extracting data: {schema.total_row_count or 'unknown'} rows, {len(schema.columns)} columns")
 
@@ -330,6 +360,9 @@ def execute_phases(
 
                 # Extract data in chunks
                 rows_generator = extractor.extract_data(resource_id, progress_callback)
+
+                # Record when this data file was created
+                schema.processed_at = datetime.now()
 
                 # Export data to file
                 export_result = data_exporter.export_data_chunked(rows_generator, schema, data_file)
@@ -377,6 +410,13 @@ def execute_phases(
 
                     # Extract schema
                     schema = extractor.extract_schema(resource_id)
+
+                    # Attach workspace metadata if processing within a workspace
+                    if workspace_id:
+                        schema.workspace_id = workspace_id
+                    if workspace_name:
+                        schema.workspace_name = workspace_name
+
                     data_exporter.export_schema(schema, schema_file)
                     logger.info(f"✓ Schema extracted: {len(schema.columns)} columns")
 

--- a/ss2db/smartsheet/models.py
+++ b/ss2db/smartsheet/models.py
@@ -253,6 +253,9 @@ class SmartsheetSchema:
     modified_at: Optional[datetime] = None
     permalink: Optional[str] = None
     source_type: str = "sheet"  # "sheet" or "report"
+    workspace_id: Optional[str] = None
+    workspace_name: Optional[str] = None
+    processed_at: Optional[datetime] = None
 
     @classmethod
     def from_sheet_response(cls, data: Dict[str, Any]) -> 'SmartsheetSchema':
@@ -326,7 +329,10 @@ class SmartsheetSchema:
             created_at=cls._parse_datetime(data.get('created_at')),
             modified_at=cls._parse_datetime(data.get('modified_at')),
             permalink=data.get('permalink'),
-            source_type=data.get('source_type', 'sheet')
+            source_type=data.get('source_type', 'sheet'),
+            workspace_id=data.get('workspace_id'),
+            workspace_name=data.get('workspace_name'),
+            processed_at=cls._parse_datetime(data.get('processed_at')),
         )
 
     @staticmethod
@@ -398,7 +404,7 @@ class SmartsheetSchema:
     def to_dict(self) -> Dict[str, Any]:
         """Convert schema to dictionary for JSON serialization."""
 
-        return {
+        result = {
             'id': self.id,
             'name': self.name,
             'source_type': self.source_type,
@@ -426,6 +432,15 @@ class SmartsheetSchema:
                 for col in self.columns
             ]
         }
+
+        if self.workspace_id is not None:
+            result['workspace_id'] = self.workspace_id
+        if self.workspace_name is not None:
+            result['workspace_name'] = self.workspace_name
+        if self.processed_at is not None:
+            result['processed_at'] = self.processed_at.isoformat()
+
+        return result
 
 
 @dataclass

--- a/ss2db/smartsheet/workspace.py
+++ b/ss2db/smartsheet/workspace.py
@@ -62,12 +62,15 @@ class WorkspaceProcessor:
         app_config: Any,
         max_workers: int,
         logger: Any = None,
+        date_prefix: Optional[str] = None,
     ):
         self.client = client
         self.config_manager = config_manager
         self.app_config = app_config
         self.max_workers = max_workers
         self.logger = logger or get_logger(__name__)
+        self.date_prefix = date_prefix
+        self.workspace_name: Optional[str] = None
 
     def process_workspace(
         self,
@@ -97,6 +100,7 @@ class WorkspaceProcessor:
         self.logger.info(f"Fetching workspace {workspace_id} contents...")
         workspace_data = self.client.get_workspace(workspace_id)
         workspace_name = workspace_data.get("name", workspace_id)
+        self.workspace_name = workspace_name
 
         # Collect all sheets
         sheets = collect_sheets_from_workspace(workspace_data)
@@ -181,8 +185,11 @@ class WorkspaceProcessor:
         start_time = time.time()
 
         try:
-            # Output goes to {output_dir}/{workspace_id}/{sheet_id}/
-            output_dir = Path(self.app_config.output.directory) / workspace_id / sheet_id
+            # Output goes to {output_dir}/[{date_prefix}/]{workspace_id}/{sheet_id}/
+            base = Path(self.app_config.output.directory)
+            if self.date_prefix:
+                base = base / self.date_prefix
+            output_dir = base / workspace_id / sheet_id
 
             success = execute_phases(
                 config_manager=self.config_manager,
@@ -200,6 +207,8 @@ class WorkspaceProcessor:
                 logger=self.logger,
                 smartsheet_client=self.client,
                 output_dir_override=output_dir,
+                workspace_id=workspace_id,
+                workspace_name=self.workspace_name,
             )
 
             duration = time.time() - start_time

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -320,6 +320,150 @@ class TestWorkspaceProcessor:
         assert "Failed: 1" in summary_text
 
 
+class TestOrganizeByDate:
+    """Tests for --organize-by-date directory structure."""
+
+    def _make_processor(self, date_prefix=None, max_workers=1):
+        """Create a WorkspaceProcessor with optional date prefix."""
+        client = Mock()
+        config_manager = Mock()
+        app_config = Mock()
+        app_config.output.directory = "/tmp/test_exports"
+        logger = Mock()
+
+        processor = WorkspaceProcessor(
+            client=client,
+            config_manager=config_manager,
+            app_config=app_config,
+            max_workers=max_workers,
+            logger=logger,
+            date_prefix=date_prefix,
+        )
+        return processor
+
+    @patch("ss2db.main.execute_phases")
+    def test_workspace_output_with_date_prefix(self, mock_execute):
+        """Workspace mode with date prefix: {output_dir}/{date}/{workspace_id}/{sheet_id}/"""
+        mock_execute.return_value = True
+        captured_calls = []
+
+        def capture_call(**kwargs):
+            captured_calls.append(kwargs)
+            return True
+
+        mock_execute.side_effect = capture_call
+
+        processor = self._make_processor(date_prefix="2026-04-06")
+        processor.client.get_workspace.return_value = WORKSPACE_FLAT
+
+        processor.process_workspace(workspace_id="1111111111111111")
+
+        assert len(captured_calls) == 2
+        for call_kwargs in captured_calls:
+            output_dir = str(call_kwargs["output_dir_override"])
+            assert output_dir.startswith("/tmp/test_exports/2026-04-06/1111111111111111/")
+            sheet_id = output_dir.split("/")[-1]
+            assert sheet_id in ["1001", "1002"]
+
+    @patch("ss2db.main.execute_phases")
+    def test_workspace_output_without_date_prefix(self, mock_execute):
+        """Workspace mode without date prefix: {output_dir}/{workspace_id}/{sheet_id}/"""
+        mock_execute.return_value = True
+        captured_calls = []
+
+        def capture_call(**kwargs):
+            captured_calls.append(kwargs)
+            return True
+
+        mock_execute.side_effect = capture_call
+
+        processor = self._make_processor(date_prefix=None)
+        processor.client.get_workspace.return_value = WORKSPACE_FLAT
+
+        processor.process_workspace(workspace_id="1111111111111111")
+
+        assert len(captured_calls) == 2
+        for call_kwargs in captured_calls:
+            output_dir = str(call_kwargs["output_dir_override"])
+            # No date component in path
+            assert "/2026-" not in output_dir
+            assert output_dir.startswith("/tmp/test_exports/1111111111111111/")
+
+    def test_date_prefix_stored_on_processor(self):
+        """date_prefix is stored and accessible on the processor."""
+        processor = self._make_processor(date_prefix="2026-04-06")
+        assert processor.date_prefix == "2026-04-06"
+
+        processor_none = self._make_processor(date_prefix=None)
+        assert processor_none.date_prefix is None
+
+
+class TestExecutePhasesDatePrefix:
+    """Tests for date prefix in execute_phases (single sheet/report mode)."""
+
+    def test_output_dir_with_date_prefix(self):
+        """Single mode with date prefix builds path: {output_dir}/{date}/{resource_id}/"""
+        from ss2db.main import execute_phases
+        from ss2db.config import Config
+
+        config = Config()
+        config.output.directory = "/tmp/test_exports"
+        config_manager = Mock()
+        logger = Mock()
+
+        # Use dry_run=True to avoid file I/O. Check the dry-run "Would save to" log messages.
+        execute_phases(
+            config_manager=config_manager,
+            app_config=config,
+            sheet_id="9999",
+            report_id=None,
+            table_name=None,
+            db_type="postgresql",
+            skip_extraction=False,
+            skip_schema=True,
+            skip_sql=True,
+            input_data=None,
+            input_schema=None,
+            dry_run=True,
+            logger=logger,
+            date_prefix="2026-04-06",
+        )
+
+        # dry_run logs "Would extract data" and "Would save to: {path}" which includes the output dir
+        all_calls = " ".join(str(c) for c in logger.info.call_args_list)
+        assert "2026-04-06" in all_calls
+
+    def test_output_dir_without_date_prefix(self):
+        """Single mode without date prefix builds path: {output_dir}/{resource_id}/"""
+        from ss2db.main import execute_phases
+        from ss2db.config import Config
+
+        config = Config()
+        config.output.directory = "/tmp/test_exports"
+        config_manager = Mock()
+        logger = Mock()
+
+        execute_phases(
+            config_manager=config_manager,
+            app_config=config,
+            sheet_id="9999",
+            report_id=None,
+            table_name=None,
+            db_type="postgresql",
+            skip_extraction=False,
+            skip_schema=True,
+            skip_sql=True,
+            input_data=None,
+            input_schema=None,
+            dry_run=True,
+            logger=logger,
+            date_prefix=None,
+        )
+
+        all_calls = " ".join(str(c) for c in logger.info.call_args_list)
+        assert "2026-04-06" not in all_calls
+
+
 class TestRateLimiterThreadSafety:
     """Tests for thread-safe RateLimiter behavior."""
 
@@ -392,6 +536,138 @@ class TestRateLimiterThreadSafety:
             t.join(timeout=30)
 
         assert errors == [], f"Threads raised exceptions: {errors}"
+
+
+class TestWorkspaceMetadata:
+    """Tests for workspace metadata in schema and JSON data files."""
+
+    def test_schema_to_dict_includes_workspace_fields(self):
+        """Schema.to_dict() includes workspace_id and workspace_name when set."""
+        from ss2db.smartsheet.models import SmartsheetSchema
+
+        schema = SmartsheetSchema(
+            id=1234,
+            name="Test Sheet",
+            columns=[],
+            workspace_id="9876543210",
+            workspace_name="My Workspace",
+        )
+
+        result = schema.to_dict()
+        assert result["workspace_id"] == "9876543210"
+        assert result["workspace_name"] == "My Workspace"
+
+    def test_schema_to_dict_includes_processed_at(self):
+        """Schema.to_dict() includes processed_at when set."""
+        from datetime import datetime
+        from ss2db.smartsheet.models import SmartsheetSchema
+
+        ts = datetime(2026, 4, 6, 14, 30, 0)
+        schema = SmartsheetSchema(
+            id=1234,
+            name="Test Sheet",
+            columns=[],
+            processed_at=ts,
+        )
+
+        result = schema.to_dict()
+        assert result["processed_at"] == "2026-04-06T14:30:00"
+
+    def test_schema_to_dict_omits_processed_at_when_none(self):
+        """Schema.to_dict() omits processed_at when not set."""
+        from ss2db.smartsheet.models import SmartsheetSchema
+
+        schema = SmartsheetSchema(id=1234, name="Test Sheet", columns=[])
+        result = schema.to_dict()
+        assert "processed_at" not in result
+
+    def test_schema_from_dict_round_trips_processed_at(self):
+        """Schema.from_dict() preserves processed_at."""
+        from datetime import datetime, timezone
+        from ss2db.smartsheet.models import SmartsheetSchema
+
+        ts = datetime(2026, 4, 6, 14, 30, 0)
+        original = SmartsheetSchema(
+            id=1234, name="Test Sheet", columns=[], processed_at=ts,
+        )
+        data = original.to_dict()
+        restored = SmartsheetSchema.from_dict(data)
+        assert restored.processed_at == ts
+
+    def test_schema_to_dict_omits_workspace_fields_when_none(self):
+        """Schema.to_dict() omits workspace fields when not set."""
+        from ss2db.smartsheet.models import SmartsheetSchema
+
+        schema = SmartsheetSchema(
+            id=1234,
+            name="Test Sheet",
+            columns=[],
+        )
+
+        result = schema.to_dict()
+        assert "workspace_id" not in result
+        assert "workspace_name" not in result
+
+    def test_schema_from_dict_round_trips_workspace_fields(self):
+        """Schema.from_dict() preserves workspace_id and workspace_name."""
+        from ss2db.smartsheet.models import SmartsheetSchema
+
+        original = SmartsheetSchema(
+            id=1234,
+            name="Test Sheet",
+            columns=[],
+            workspace_id="9876543210",
+            workspace_name="My Workspace",
+        )
+
+        data = original.to_dict()
+        restored = SmartsheetSchema.from_dict(data)
+
+        assert restored.workspace_id == "9876543210"
+        assert restored.workspace_name == "My Workspace"
+
+    def test_schema_from_dict_without_workspace_fields(self):
+        """Schema.from_dict() handles missing workspace fields gracefully."""
+        from ss2db.smartsheet.models import SmartsheetSchema
+
+        data = {"id": 1234, "name": "Test Sheet", "columns": []}
+        restored = SmartsheetSchema.from_dict(data)
+
+        assert restored.workspace_id is None
+        assert restored.workspace_name is None
+
+    @patch("ss2db.main.execute_phases")
+    def test_workspace_processor_passes_workspace_metadata(self, mock_execute):
+        """WorkspaceProcessor passes workspace_id and workspace_name to execute_phases."""
+        captured_calls = []
+
+        def capture_call(**kwargs):
+            captured_calls.append(kwargs)
+            return True
+
+        mock_execute.side_effect = capture_call
+
+        client = Mock()
+        client.get_workspace.return_value = WORKSPACE_FLAT
+        config_manager = Mock()
+        app_config = Mock()
+        app_config.output.directory = "/tmp/test_exports"
+        logger = Mock()
+
+        processor = WorkspaceProcessor(
+            client=client,
+            config_manager=config_manager,
+            app_config=app_config,
+            max_workers=1,
+            logger=logger,
+        )
+
+        processor.process_workspace(workspace_id="1111111111111111")
+
+        assert len(captured_calls) == 2
+        for call_kwargs in captured_calls:
+            assert call_kwargs["workspace_id"] == "1111111111111111"
+            assert call_kwargs["workspace_name"] == "Test Workspace"
 
 
 class TestGetWorkspace:


### PR DESCRIPTION
## Summary
- Add `--organize-by-date` CLI flag that uses `YYYY-MM-DD` as the top-level output directory for date-based export organization
  - Single mode: `exports/YYYY-MM-DD/{resource_id}/`
  - Workspace mode: `exports/YYYY-MM-DD/{workspace_id}/{sheet_id}/`
- Add `workspace_id` and `workspace_name` to JSON data file metadata when processing within a workspace
- Add `processed_at` ISO timestamp to all JSON data file metadata recording when each export was created

Closes #9

## Test plan
- [x] 134 tests passing (8 new tests for date organization, workspace metadata, and processed_at)
- [ ] Manual: `ss2db --sheet-id 123 --organize-by-date --dry-run --verbose` — verify date-prefixed path in logs
- [ ] Manual: `ss2db --workspace-id 456 --organize-by-date --dry-run --verbose` — verify nested date path
- [ ] Manual: Verify `workspace_id`, `workspace_name`, and `processed_at` fields appear in exported JSON metadata